### PR TITLE
Add overrides

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "@brinkninja/core": "^1.0.0",
     "@brinkninja/verifiers": "^1.0.0",
     "@brinkninja/utils": "^0.3.1",
+    "@nomiclabs/hardhat-ethers": "^2.0.4",
     "bignumber.js": "^9.0.1",
     "eth-lib": "^0.1.29",
     "eth-sig-util": "^2.5.3",

--- a/src/Account.js
+++ b/src/Account.js
@@ -80,13 +80,15 @@ class Account {
 
       this.estimateGas[fnName] = (async function () {
         const { contract, contractName, functionName, paramTypes, params } = await fn.apply(this, arguments)
-        const gas = await contract.estimateGas[functionName].apply(contract, params)
+        let txOptions = arguments[fn.length] || {}
+        const gas = await contract.estimateGas[functionName].apply(contract, [...params, txOptions])
         return { contractName, functionName, paramTypes, params, gas }
       }).bind(this)
 
       this.populateTransaction[fnName] = (async function () {
         const { contract, contractName, functionName, paramTypes, params } = await fn.apply(this, arguments)
-        const txData = await contract.populateTransaction[functionName].apply(contract, params)
+        let txOptions = arguments[fn.length] || {}
+        const txData = await contract.populateTransaction[functionName].apply(contract, [...params, txOptions])
         return {
           contractName, functionName, paramTypes, params,
           ...txData
@@ -95,7 +97,8 @@ class Account {
 
       this.callStatic[fnName] = (async function () {
         const { contract, contractName, functionName, paramTypes, params } = await fn.apply(this, arguments)
-        const returnValues = await contract.callStatic[functionName].apply(contract, params)
+        let txOptions = arguments[fn.length] || {}
+        const returnValues = await contract.callStatic[functionName].apply(contract, [...params, txOptions])
         return { contractName, functionName, paramTypes, params, returnValues }
       }).bind(this)
     }

--- a/yarn.lock
+++ b/yarn.lock
@@ -605,6 +605,11 @@
     "@ethersproject/properties" "^5.4.0"
     "@ethersproject/strings" "^5.4.0"
 
+"@nomiclabs/hardhat-ethers@^2.0.4":
+  version "2.0.4"
+  resolved "https://registry.yarnpkg.com/@nomiclabs/hardhat-ethers/-/hardhat-ethers-2.0.4.tgz#288889c338acaf47cabd29020e561d0077b7efcf"
+  integrity sha512-7LMR344TkdCYkMVF9LuC9VU2NBIi84akQiwqm7OufpWaDgHbWhuanY53rk3SVAW0E4HBk5xn5wl5+bN5f+Mq5w==
+
 "@openzeppelin/contracts@4.3.3":
   version "4.3.3"
   resolved "https://registry.yarnpkg.com/@openzeppelin/contracts/-/contracts-4.3.3.tgz#ff6ee919fc2a1abaf72b22814bfb72ed129ec137"


### PR DESCRIPTION
this adds a passthrough of ethers.js override options (gas, gasLimit, etc) for each of the wrapper functions `estimateGas`, `populateTransaction`, and `callStatic`