### PR TITLE
ledger workaround, convert 00/01 v values in ECDSA sig to 27/28

### DIFF
--- a/src/AccountSigner.js
+++ b/src/AccountSigner.js
@@ -6,6 +6,7 @@ const {
   TRANSFER_VERIFIER,
   CANCEL_VERIFIER
 } = require('@brinkninja/verifiers/constants')
+const sigToValidECDSA = require('./utils/sigToValidECDSA')
 const proxyAccountFromOwner = require('./proxyAccountFromOwner')
 const encodeFunctionCall = require('./encodeFunctionCall')
 const {
@@ -178,7 +179,7 @@ class AccountSigner {
       }
     }
 
-    const { typedData, typedDataHash, signature } = await signEIP712({
+    const { typedData, typedDataHash, signature: sigFromSigner } = await signEIP712({
       signer: this._signer,
       contractAddress: await this.accountAddress(),
       contractName: 'BrinkAccount',
@@ -190,6 +191,7 @@ class AccountSigner {
     })
 
     const signerAddress = await this._signer.getAddress()
+    const { signature } = sigToValidECDSA(sigFromSigner)
 
     return {
       message: typedDataHash,

--- a/src/utils/sigToValidECDSA.js
+++ b/src/utils/sigToValidECDSA.js
@@ -1,0 +1,30 @@
+const { isHex } = require('web3-utils')
+
+function sigToValidECDSA (signature) {
+  if (!signature || signature.length !== 132 || signature.slice(0,2) !== '0x' || !isHex(signature)) {
+    throw new Error(`sigToValidECDSA: Invalid signature: ${signature}`)
+  }
+
+  const r = lower(signature.slice(2, 2+64))
+  const s = lower(signature.slice(2+64, 2+64+64))
+  let v = lower(signature.slice(2+64+64, 2+64+64+64+2))
+
+  if (v !== '00' && v !== '01' && v !== '1b' && v !== '1c') {
+    throw new Error(`sigToValidECDSA: Invalid \'v\' value: ${signature}`)
+  }
+
+  // convert to valid v values for ECDSA lib.
+  // some signers, ledger for example, sign with 0/1 instead of 27/28 for v values,
+  // and openzeppelin ECDSA library considers these invalid
+  if (v == '00') v = '1b'
+  else if (v == '01') v = '1c'
+
+  return {
+    signature: `0x${r}${s}${v}`,
+    r, s, v
+  }
+}
+
+const lower = s => s.toLowerCase()
+
+module.exports = sigToValidECDSA

--- a/test/AccountSigner.test.js
+++ b/test/AccountSigner.test.js
@@ -4,6 +4,8 @@ const { randomHex } = require('web3-utils')
 const { BN: ethersBN } = require('@brinkninja/utils')
 const { toBN: web3BN } = require('web3-utils')
 const { solidity } = require('ethereum-waffle')
+const sigToValidECDSA = require('../src/utils/sigToValidECDSA')
+
 const BN = ethers.BigNumber.from
 chai.use(solidity)
 const { expect } = chai
@@ -215,6 +217,20 @@ describe('AccountSigner', function () {
       it('signTokenToTokenSwap should correctly encode web3 BN', async function () {
         await tokenToTokenSignWithBnTest.call(this, web3BN)
       })
+    })
+  })
+
+  describe('Wrong \'v\' value in signature (Ledger)', function() {
+    it('when signer signs with invalid ECDSA \'v\' value', async function () {
+      // sign with the "bad v" signer that mocks what ledger does
+      const signedEthTransfer = await this.accountSignerBadV.signEthTransfer(
+        '0', '1', randomHex(20), ethers.utils.parseEther('1.0').toString()
+      )
+
+      const { signature } = signedEthTransfer
+      const v = signature.slice(2+64+64, 2+64+64+2)
+        
+      expect(v == '1b' || v == '1c').to.be.true
     })
   })
 })

--- a/test/helpers/mockLedgerSignerBadV.js
+++ b/test/helpers/mockLedgerSignerBadV.js
@@ -1,0 +1,21 @@
+const randomSigner = require('./randomSigner')
+
+async function mockLedgerSignerBadV () {
+  const rndSigner = await randomSigner()
+
+  const fn = rndSigner._signTypedData
+  rndSigner._signTypedData = (async function (domain, types, value) {
+    const signature = await fn.call(rndSigner, domain, types, value)
+
+    // mock in a bad 'v' value to mock ledger's bad behavior .. changes 1b to 00, and 1c to 01
+    const v = signature.slice(2+64+64, 2+64+64+2)
+    const badV = v == '1b' ? '00' : '01'
+
+    // return the signature string with the bad v value
+    return `${signature.slice(0, 2+64+64)}${badV}`
+  }).bind(rndSigner)
+
+  return rndSigner
+}
+
+module.exports = mockLedgerSignerBadV

--- a/test/helpers/randomSigner.js
+++ b/test/helpers/randomSigner.js
@@ -7,7 +7,7 @@ async function randomSigner () {
   // fund the randomly created wallet signer with some eth
   await defaultSigner.sendTransaction({
     to: signer.address,
-    value: ethers.BigNumber.from('10000000000000000000000000')
+    value: ethers.BigNumber.from('100000000000000000000')
   })
 
   return signer

--- a/test/setupTeardown.js
+++ b/test/setupTeardown.js
@@ -5,6 +5,7 @@ const { BN, constants, encodeFunctionCall } = require('@brinkninja/utils')
 const { MAX_UINT256 } = constants
 const brink = require('../index')
 const randomSigner = require('./helpers/randomSigner')
+const mockLedgerSignerBadV = require('./helpers/mockLedgerSignerBadV')
 
 beforeEach(async function () {
   this.accountContract = await deploySaltedContract('Account')
@@ -19,6 +20,7 @@ beforeEach(async function () {
   this.defaultSigner = signers[0]
 
   this.ethersAccountSigner = await randomSigner()
+  this.ethersAccountBadVSigner = await mockLedgerSignerBadV()
   this.ownerAddress = this.ethersAccountSigner.address
 
   // account uses ethers signer 0 (not the account owner, it's acting as an executor)
@@ -41,6 +43,9 @@ beforeEach(async function () {
 
   // accountSigner uses ethers signer 1 (it's acting as the owner of the Brink account)
   this.accountSigner = brink.accountSigner(this.ethersAccountSigner, 'hardhat')
+
+  // accountSigner that signs "ledger style" with bad 'v' values 00 and 01
+  this.accountSignerBadV = brink.accountSigner(this.ethersAccountBadVSigner, 'hardhat')
 
   this.token = await deploySaltedContract(
     'TestERC20',


### PR DESCRIPTION
ledger signs with 00/01 for the v value, but the openzeppelin ECDSA library we're using for brink-core requires the v value to be 27/28