### PR TITLE
sdk v5: Fix entrypoint

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "web3-utils": "^1.7.3"
   },
   "license": "GPL-3.0-or-later",
+  "main": "build/index.js",
   "scripts": {
     "test": "hardhat test",
     "build": "rm -rf build && tsc"


### PR DESCRIPTION
With current config, sdk need to be used as 
```javascript
import brink from `@brinkninja/sdk/build`
```
This changes removes the `/build` when importing