### PR TITLE
[BRI-957] fixed race condition with evm contract call

### DIFF
--- a/src/swaps/getLimitSwapFilledAmount.ts
+++ b/src/swaps/getLimitSwapFilledAmount.ts
@@ -17,7 +17,7 @@ export default async function getLimitSwapFilledAmount ({
   let result
   try {
     result = await evm.callContractFn(
-      evm.SwapIO,
+      'SwapIO',
       'getFilledAmount',
       {
         id: BigInt(0), // SwapIO call for getFilledAmount doesn't use id

--- a/src/swaps/getLimitSwapUnfilledAmount.ts
+++ b/src/swaps/getLimitSwapUnfilledAmount.ts
@@ -17,7 +17,7 @@ export default async function getLimitSwapUnfilledAmount ({
   let result
   try {
     result = await evm.callContractFn(
-      evm.SwapIO,
+      'SwapIO',
       'getUnfilledAmount',
       {
         id: BigInt(0), // SwapIO call for getUnfilledAmount doesn't use id

--- a/src/swaps/limitSwapExactInput_getOutput.ts
+++ b/src/swaps/limitSwapExactInput_getOutput.ts
@@ -26,7 +26,7 @@ export default async function limitSwapExactInput_getOutput ({
   let result
   try {
     result = await evm.callContractFn(
-      evm.SwapIO,
+      'SwapIO',
       'limitSwapExactInput_getOutput',
       BigInt(input),
       BigInt(filledInput),

--- a/src/swaps/limitSwapExactOutput_getInput.ts
+++ b/src/swaps/limitSwapExactOutput_getInput.ts
@@ -26,7 +26,7 @@ export default async function limitSwapExactInput_getOutput ({
   let result
   try {
     result = await evm.callContractFn(
-      evm.SwapIO,
+      'SwapIO',
       'limitSwapExactInput_getOutput',
       BigInt(output),
       BigInt(filledOutput),

--- a/src/swaps/marketSwapExactInput_getOutput.ts
+++ b/src/swaps/marketSwapExactInput_getOutput.ts
@@ -29,7 +29,7 @@ export default async function marketSwapExactInput_getOutput ({
   let result
   try {
     result = await evm.callContractFn(
-      evm.SwapIO,
+      'SwapIO',
       'marketSwapExactInput_getOutput',
       BigInt(input),
       BigInt(priceX96),

--- a/src/swaps/marketSwapExactOutput_getInput.ts
+++ b/src/swaps/marketSwapExactOutput_getInput.ts
@@ -24,7 +24,7 @@ export default async function marketSwapExactOutput_getInput ({
   feeMin
 }: marketSwapExactOutput_getInputArgs): Promise<marketSwapExactOutput_getInputResult> {
   const result = await evm.callContractFn(
-    evm.SwapIO,
+    'SwapIO',
     'marketSwapExactOutput_getInput',
     BigInt(output),
     BigInt(priceX96),


### PR DESCRIPTION
contract cannot be loaded until after vm is initialized. fixed this by changing the contract calls to use contract name string, and load contract after vm init