### PR TITLE
Fix github action that run tests

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -21,3 +21,5 @@ jobs:
       run: yarn install
     - name: Run tests
       run: yarn test
+      env:
+        MAINNET_RPC_URL: ${{ secrets.MAINNET_RPC_URL }}


### PR DESCRIPTION
We were missing the MAINNET_RPC_URL to run `test-fork`