### PR TITLE
[BRI-1824] Fix signedDeclaration.validate()

### DIFF
--- a/src/intents/SignedDeclaration.ts
+++ b/src/intents/SignedDeclaration.ts
@@ -42,8 +42,14 @@ class SignedDeclaration {
         value,
         this.signature
       )
-    } catch (e) {
-      return invalidResult('SIGNATURE_MISMATCH')
+    } catch (e: any) {
+      // catching exception when signature is invalid
+      // "message signature missing v and recoveryParam (argument="signature", value="0x32f", code=INVALID_ARGUMENT, version=bytes/5.7.0)"
+      if (e.message.includes('signature missing v and recoveryParam')) {
+        return invalidResult('VERIFY_TYPED_DATA_FAILED')
+      } else {
+        throw e
+      }
     }
     if (recoveredAddress.toLowerCase() !== this.signer.toLowerCase()) {
       return invalidResult('SIGNATURE_MISMATCH')

--- a/src/intents/SignedDeclaration.ts
+++ b/src/intents/SignedDeclaration.ts
@@ -32,12 +32,19 @@ class SignedDeclaration {
     }
 
     const { domain, types, value } = await this.EIP712Data()
-    const recoveredAddress = ethers.utils.verifyTypedData(
-      domain,
-      types,
-      value,
-      this.signature
-    )
+
+    let recoveredAddress;
+
+    try {
+      recoveredAddress = ethers.utils.verifyTypedData(
+        domain,
+        types,
+        value,
+        this.signature
+      )
+    } catch (e) {
+      return invalidResult('SIGNATURE_MISMATCH')
+    }
     if (recoveredAddress.toLowerCase() !== this.signer.toLowerCase()) {
       return invalidResult('SIGNATURE_MISMATCH')
     }

--- a/test/local/SignedIntentGroup.test.ts
+++ b/test/local/SignedIntentGroup.test.ts
@@ -27,6 +27,18 @@ describe('SignedDeclaration', function () {
       expect(validationResult.valid).to.equal(false)
       expect(validationResult.reason).to.equal('SIGNATURE_MISMATCH')
     })
+
+    it('validate should return false when typed data cannot be verified', async function () {
+      const declarationData = await buildDeclaration()
+      const signedDeclaration = await signDeclaration(this.ethersAccountSigner, declarationData)
+
+      const invalidSignature = '0x' + Math.floor(Math.random() * 1000).toString(16).padStart(3, '0');
+      signedDeclaration.signature = invalidSignature;
+
+      const validate = await signedDeclaration.validate()
+
+      expect(validate.valid).to.equal(false)
+    })
   })
 })
 


### PR DESCRIPTION
https://linear.app/brink-trade/issue/BRI-1824/signeddeclarationvalidate-throws-instead-of-return-invalid