### PR TITLE
Add eip712 attribute to SignedDecalaration

### DIFF
--- a/src/intents/SignedDeclaration.ts
+++ b/src/intents/SignedDeclaration.ts
@@ -15,6 +15,7 @@ class SignedDeclaration {
   signature: string
   declaration: Declaration
   declarationContract: string
+  eip712Data?: EIP712TypedData | null
 
   constructor(signedDeclaration: SignedDeclarationArgs) {
     this.signer = signedDeclaration.signer
@@ -23,6 +24,7 @@ class SignedDeclaration {
     this.signature = signedDeclaration.signature
     this.declaration = new Declaration(signedDeclaration.declaration)
     this.declarationContract = signedDeclaration.declarationContract
+    this.eip712Data = signedDeclaration.eip712Data
   }
 
   async validate (): Promise<ValidationResult> {
@@ -50,6 +52,8 @@ class SignedDeclaration {
   }
 
   async EIP712Data (declarationData?: string): Promise<EIP712TypedData> {
+    if (this.eip712Data) return this.eip712Data;
+
     const domain = {
       name: 'BrinkAccount',
       version: '1',
@@ -65,12 +69,15 @@ class SignedDeclaration {
         declarationData || (await this.declaration.toJSON()).data
       ]
     )
-    return {
+
+    this.eip712Data = {
       domain,
       types: typedData.types,
       value: typedData.value,
       hash: typedDataHash
     }
+
+    return this.eip712Data
   }
 
   async toJSON (): Promise<SignedDeclarationJSON> {

--- a/test/local/SignedDeclaration.test.ts
+++ b/test/local/SignedDeclaration.test.ts
@@ -28,6 +28,14 @@ describe('SignedDeclaration', function () {
       expect(validationResult.reason).to.equal('SIGNATURE_MISMATCH')
     })
   })
+  describe('EIP712Data()', function () {
+    it('Should store eip712Data', async function () {
+      const declarationData = await buildDeclaration()
+      const signedDeclaration = await signDeclaration(this.ethersAccountSigner, declarationData)
+      const eip712Data = await signedDeclaration.EIP712Data()
+      expect(signedDeclaration.eip712Data).to.equal(eip712Data)
+    })
+  })
 })
 
 async function buildDeclaration () {


### PR DESCRIPTION
The objective of this PR is to store EIP712 data when is available in the Intent pool. Using stored EIP712, we reduce the processing time for each declaration. 
If EIP712 data isn't provided to the constructor, is generated with `EIP712()` method